### PR TITLE
:bug: Fix: Align entity with database table structure

### DIFF
--- a/src/main/java/com/grepp/diary/app/model/diary/entity/DiaryImg.java
+++ b/src/main/java/com/grepp/diary/app/model/diary/entity/DiaryImg.java
@@ -6,12 +6,16 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
 @Entity
 @Getter @Setter @ToString
+@NoArgsConstructor
+@Table(name="IMAGE")
 public class DiaryImg {
 
     @Id
@@ -23,4 +27,8 @@ public class DiaryImg {
     private String originName;
     private String renamedName;
     private Boolean isUse;
+
+    public String getRenamedPath(){
+        return "/download/" + savePath + renamedName;
+    }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 🐛  Fix: Align entity with database table structure
- 엔티티명(DiaryImg)와 테이블명(IMAGE)가 달라서 JPA를 통한 쿼리 생성시 테이블을 검색할 수 없던 문제를 해결했습니다.
- DiaryImg 엔티티에 `@TABLE` 어노테이션을 통해 명시적으로 테이블명을 선언했습니다.