### PR TITLE
UI updates & New navigation feature to writing  from calendar date click

### DIFF
--- a/src/main/java/com/grepp/diary/app/controller/api/diary/DiaryApiController.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/diary/DiaryApiController.java
@@ -62,4 +62,14 @@ public class DiaryApiController {
 
         return diaryService.getUserDiaryCount(userId, start, end);
     }
+
+    @GetMapping("/check")
+    public boolean checkDiaryOfDay(
+        @RequestParam String userId,
+        @RequestParam LocalDate date
+    ) {
+        LocalDate nextDate = date.plusDays(1);
+
+        return !diaryService.getDiariesDateBetween(userId, date, nextDate).isEmpty();
+    }
 }

--- a/src/main/java/com/grepp/diary/app/controller/api/keyword/KeywordApiController.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/keyword/KeywordApiController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("api/keyword")
 public class KeywordApiController {
-    //TODO : Controller 키워드 랭킹 매서드 작성
     private final KeywordService keywordService;
     private final DateUtil dateUtil;
 

--- a/src/main/java/com/grepp/diary/app/controller/web/diary/DiaryController.java
+++ b/src/main/java/com/grepp/diary/app/controller/web/diary/DiaryController.java
@@ -4,17 +4,20 @@ import com.grepp.diary.app.controller.web.diary.payload.DiaryRequest;
 import com.grepp.diary.app.model.diary.DiaryService;
 import com.grepp.diary.app.model.keyword.KeywordService;
 import com.grepp.diary.app.model.keyword.entity.Keyword;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 @Controller
@@ -27,7 +30,14 @@ public class DiaryController {
     private final KeywordService keywordService;
 
     @GetMapping
-    public String showDiaryWritePage(Model model) {
+    public String showDiaryWritePage(
+        @RequestParam(value = "date", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+        Model model
+    ) {
+        LocalDate targetDate = (date != null) ? date : LocalDate.now();
+        model.addAttribute("diaryDate", targetDate);
+
         model.addAttribute("diaryRequest", new DiaryRequest());
         List<Keyword> allKeywords = keywordService.findAllKeywordEntities();
         Map<String, List<Keyword>> grouped = allKeywords.stream()

--- a/src/main/resources/static/css/card-timeline.css
+++ b/src/main/resources/static/css/card-timeline.css
@@ -8,7 +8,7 @@
 }
 
 .timeline-title {
-  font-size: 36px;
+  font-size: 1.8rem;
   font-weight: bold;
   margin-top: 30px;
   margin-bottom: 15px;

--- a/src/main/resources/static/css/diary.css
+++ b/src/main/resources/static/css/diary.css
@@ -1,20 +1,18 @@
-body {
-  font-family: 'Noto Sans KR', sans-serif;
-  background-color: #eef2ec;
-  margin: 0;
-}
-
 .container {
   display: flex;
   margin-left: 200px;
 }
 
-.content {
-  padding: 40px;
-  width: 100%;
+.container {
+  display: flex;
+  flex-direction: column;
+  max-width: 800px;
+  margin: 30px auto;
+  align-content: center;
+  padding: 0 16px;
 }
 
-h1 {
+h2 {
   margin-bottom: 30px;
   font-size: 1.8rem;
 }
@@ -23,31 +21,36 @@ h1 {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 1.1rem;
-  margin-bottom: 20px;
+}
+
+.date-text {
+  font-size: 1.2rem;
+  font-weight: normal;
+  display: flex;
+  align-items: center;
 }
 
 .date-change {
-  background-color: #6b8e6e;
+  background-color: #467750;
   border: none;
-  color: white;
-  padding: 5px 10px;
+  width: 130px;
+  height: 42px;
+  color: #FEFBF6;
   border-radius: 5px;
   cursor: pointer;
 }
 
 .form-group {
   width: 100%;
-  max-width: 688px;
 }
 
 .form-box {
   background-color: #FEFBF6;
+  width: 100%;
   padding: 24px;
   border-radius: 12px;
   margin-bottom: 24px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
-  max-width: 640px;
 }
 
 .image-preview-box {

--- a/src/main/resources/static/js/calendar.js
+++ b/src/main/resources/static/js/calendar.js
@@ -24,6 +24,8 @@ function renderCalendar(date, emotionMap = {}) {
 
   // 날짜 셀 생성
   const today = new Date();
+  today.setHours(0, 0, 0, 0);  // 오늘 기준 정규화
+
   for (let d = 1; d <= lastDate; d++) {
     const cell = document.createElement("div");
     cell.className = "date-cell";
@@ -61,6 +63,34 @@ function renderCalendar(date, emotionMap = {}) {
       number.classList.add("today-number");
     }
 
+    // 날짜 클릭 이벤트 등록
+    cell.addEventListener("click", async () => {
+      const clickedDate = new Date(year, month, d);
+      clickedDate.setHours(0, 0, 0, 0);
+
+      const tomorrow = new Date(today);
+      tomorrow.setDate(today.getDate() + 1);
+
+      if (clickedDate >= tomorrow) {
+        return; // 내일 이후는 무시
+      }
+
+      const dateParam = `${year}-${String(month + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+
+      try {
+        const res = await fetch(`/api/diary/check?userId=user01&date=${dateParam}`);
+        const exists = await res.json();
+
+        if (exists) {
+          window.location.href = `/diary/view?date=${dateParam}`; // 일기가 있는 경우
+        } else {
+          window.location.href = `/diary?date=${dateParam}`;  // 일기가 없는 경우
+        }
+      } catch (err) {
+        console.error("날짜 클릭 처리 중 오류:", err);
+      }
+    });
+
     cell.appendChild(circle);
     cell.appendChild(number);
     grid.appendChild(cell);
@@ -95,6 +125,5 @@ document.getElementById("go-today").addEventListener("click", () => {
   fetchEmotionData(currentDate.getFullYear(), currentDate.getMonth() + 1);
 });
 
-
-
+// 초기 렌더링
 fetchEmotionData(currentDate.getFullYear(), currentDate.getMonth() + 1);

--- a/src/main/resources/templates/diary/diary.html
+++ b/src/main/resources/templates/diary/diary.html
@@ -3,25 +3,26 @@
 <head>
   <meta charset="UTF-8">
   <title>일기 작성</title>
-  <link rel="stylesheet" th:href="@{/css/diary.css}">
+  <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/sidebar.css">
+  <link rel="stylesheet" th:href="@{/css/diary.css}">
   <link rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
-  <div th:replace="~{fragments/member-sidebar :: memberSidebar}"></div>
+  <div th:replace="fragments/member-sidebar :: memberSidebar"></div>
 
-  <div class="container">
+  <div class="main">
 
-    <div class="content">
-      <h1>오늘의 일기를 작성해 볼까요?</h1>
+    <div class="container">
+      <h2>오늘의 일기를 작성해 볼까요?</h2>
 
       <form th:action="@{/diary}" method="post" enctype="multipart/form-data" th:object="${diaryRequest}">
 
         <!-- 날짜 표기 (예: 5월 12일 월요일) -->
         <div class="form-box">
           <div class="date-display">
-            <span th:text="${#temporals.format(T(java.time.LocalDate).now(), 'M월 d일 E요일')}"></span>
+            <div class="date-text" th:text="${#temporals.format(diaryDate, 'M월 d일 E요일')}"></div>
             <button type="button" class="date-change">날짜 변경</button>
           </div>
         </div>


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 설명
- 일기 작성 페이지의 UI를 소폭 수정했습니다.
- 홈 화면에서 캘린더 날짜 클릭시 일기가 없을 때 해당 일자의 일기 작성페이지로 이동하는 기능을 구현하였습니다.

## 👩‍💻 구현 내용
### 💡 Remove TODO comment
- 개발이 완료된 내용에 대한 TODO 주석을 삭제하였습니다.

### 💄 Update diary writing UI
- 기존의 작성페이지에서 요소들이 중앙정렬이 되어있지 않았던 문제를 해결하였습니다.
- 기존의 작성페이지에서 배경 색상이 기본색상과 맞지 않던 문제를 해결하였습니다.
- 날짜번경 버튼의 색상이 기획과 다르게 되어있던 문제를 해결하였습니다.

### 💄 Resize timeline title font
- 기존의 타임라인페이지에서 페이지 타이틀이 다른 페이지에 비해 지나치게 컸던 문제를 해결하였습니다.

### ✨ feat: enable diary writing navigation from calendar date click
- 홈 화면에서 캘린더의 날짜 클릭시 일기가 작성되어 있지 않은 날이라면 해당 날의 일기 작성페이지로 이동하는 기능을 구현하였습니다.

## ✅ PR 포인트
- 작성페이지 이동 기능 구현 중, 기존의 DiaryController내의 매서드를 수정하였습니다. 작성페이지에 날짜정보를 보낼 수 있기 위해 param을 추가하였고, 추가적인 로직이 기존의 로직을 건드린 부분은 없기에 문제는 발생하지 않았습니다.