### PR TITLE
AI Setting Feature Implements & Improve UI

### DIFF
--- a/src/main/java/com/grepp/diary/app/controller/api/ai/AiApiController.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/ai/AiApiController.java
@@ -1,8 +1,10 @@
 package com.grepp.diary.app.controller.api.ai;
 
+import com.grepp.diary.app.controller.api.ai.payload.AiListResponse;
 import com.grepp.diary.app.controller.api.ai.payload.ChatRequest;
 import com.grepp.diary.app.controller.api.ai.payload.Message;
 import com.grepp.diary.app.model.ai.AiChatService;
+import com.grepp.diary.app.model.ai.AiService;
 import com.grepp.diary.app.model.ai.entity.Ai;
 import com.grepp.diary.app.model.custom.entity.Custom;
 import com.grepp.diary.app.model.diary.DiaryService;
@@ -23,14 +25,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 @Controller
+@RestController
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("api/ai")
 public class AiApiController {
 
     private final AiChatService aiChatService;
+    private final AiService aiService;
     private final DiaryService diaryService;
     private final MemberService memberService;
 
@@ -195,5 +200,10 @@ public class AiApiController {
         }
 
         return builder.append("\n일기 내용: ").append(content).toString();
+    }
+
+    @GetMapping("/list")
+    private AiListResponse getAiInfoList() {
+        return AiListResponse.fromDtoList(aiService.getAIList());
     }
 }

--- a/src/main/java/com/grepp/diary/app/controller/api/ai/payload/AiListResponse.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/ai/payload/AiListResponse.java
@@ -1,0 +1,29 @@
+package com.grepp.diary.app.controller.api.ai.payload;
+
+import com.grepp.diary.app.model.ai.dto.AiInfoDto;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record AiListResponse(
+    List<AiInfo> aiInfoList
+) {
+    public record AiInfo(
+        String name,
+        String mbti,
+        String info,
+        String savePath
+    ) {
+        public static AiInfo fromDto(AiInfoDto aiInfoDto) {
+            return new AiInfo(
+                aiInfoDto.getName(),
+                aiInfoDto.getMbti(),
+                aiInfoDto.getInfo(),
+                aiInfoDto.getImgUrl()
+            );
+        }
+    }
+    public static AiListResponse fromDtoList(List<AiInfoDto> aiInfoDtoList) {
+        List<AiInfo> aiInfoList = aiInfoDtoList.stream().map(AiInfo::fromDto).toList();
+        return new AiListResponse(aiInfoList);
+    }
+}

--- a/src/main/java/com/grepp/diary/app/controller/api/ai/payload/AiListResponse.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/ai/payload/AiListResponse.java
@@ -3,11 +3,13 @@ package com.grepp.diary.app.controller.api.ai.payload;
 import com.grepp.diary.app.model.ai.dto.AiInfoDto;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 
 public record AiListResponse(
     List<AiInfo> aiInfoList
 ) {
     public record AiInfo(
+        Integer id,
         String name,
         String mbti,
         String info,
@@ -15,6 +17,7 @@ public record AiListResponse(
     ) {
         public static AiInfo fromDto(AiInfoDto aiInfoDto) {
             return new AiInfo(
+                aiInfoDto.getAiId(),
                 aiInfoDto.getName(),
                 aiInfoDto.getMbti(),
                 aiInfoDto.getInfo(),

--- a/src/main/java/com/grepp/diary/app/controller/api/custom/CustomApiController.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/custom/CustomApiController.java
@@ -1,0 +1,25 @@
+package com.grepp.diary.app.controller.api.custom;
+
+import com.grepp.diary.app.controller.api.custom.payload.CustomResponse;
+import com.grepp.diary.app.model.custom.CustomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/custom")
+public class CustomApiController {
+
+    private final CustomService customService;
+
+    @GetMapping
+    public CustomResponse getCustomAiByUserId(
+        Authentication authentication
+    ) {
+        String userId = authentication.getName();
+        return CustomResponse.fromDto(customService.getCustomAiByUserId(userId));
+    }
+}

--- a/src/main/java/com/grepp/diary/app/controller/api/custom/payload/CustomResponse.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/custom/payload/CustomResponse.java
@@ -1,0 +1,13 @@
+package com.grepp.diary.app.controller.api.custom.payload;
+
+import com.grepp.diary.app.model.custom.dto.CustomAIDto;
+
+public record CustomResponse(
+    String name,
+    boolean isFormal,
+    boolean isLong
+) {
+    public static CustomResponse fromDto(CustomAIDto customAIDto) {
+        return new CustomResponse(customAIDto.getName(), customAIDto.isFormal(), customAIDto.isLong());
+    }
+}

--- a/src/main/java/com/grepp/diary/app/controller/api/custom/payload/CustomResponse.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/custom/payload/CustomResponse.java
@@ -1,13 +1,14 @@
 package com.grepp.diary.app.controller.api.custom.payload;
 
 import com.grepp.diary.app.model.custom.dto.CustomAIDto;
+import lombok.extern.slf4j.Slf4j;
 
 public record CustomResponse(
-    String name,
+    Integer aiId,
     boolean isFormal,
     boolean isLong
 ) {
     public static CustomResponse fromDto(CustomAIDto customAIDto) {
-        return new CustomResponse(customAIDto.getName(), customAIDto.isFormal(), customAIDto.isLong());
+        return new CustomResponse(customAIDto.getAiId(), customAIDto.isFormal(), customAIDto.isLong());
     }
 }

--- a/src/main/java/com/grepp/diary/app/controller/api/diary/payload/DiaryCalendarResponse.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/diary/payload/DiaryCalendarResponse.java
@@ -11,13 +11,13 @@ public record DiaryCalendarResponse(
     public record DiaryEmotion(
         Integer diaryId,
         Emotion emotion,
-        LocalDate createdAt
+        LocalDate diaryDate
     ){
         public static DiaryEmotion fromEntity(Diary diary) {
             return new DiaryEmotion(
                 diary.getDiaryId(),
                 diary.getEmotion(),
-                diary.getCreatedAt().toLocalDate()
+                diary.getDate()
             );
         }
     }

--- a/src/main/java/com/grepp/diary/app/controller/api/diary/payload/DiaryCardResponse.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/diary/payload/DiaryCardResponse.java
@@ -10,6 +10,7 @@ public record DiaryCardResponse (
 ){
     public record DiaryCard(
         Integer diaryId,
+        LocalDate date,
         LocalDate createdAt,
         Emotion emotion,
         String content,
@@ -25,6 +26,7 @@ public record DiaryCardResponse (
             return new DiaryCard(
                 diary.getDiaryId(),
                 diary.getCreatedAt().toLocalDate(),
+                diary.getDate(),
                 diary.getEmotion(),
                 diary.getContent(),
                 imagePath

--- a/src/main/java/com/grepp/diary/app/controller/web/custom/CustomController.java
+++ b/src/main/java/com/grepp/diary/app/controller/web/custom/CustomController.java
@@ -1,0 +1,50 @@
+package com.grepp.diary.app.controller.web.custom;
+
+import com.grepp.diary.app.controller.web.custom.form.SettingAiForm;
+import com.grepp.diary.app.model.custom.CustomService;
+import com.grepp.diary.app.model.custom.dto.CustomAIDto;
+import java.util.jar.Attributes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("custom")
+public class CustomController {
+
+    private final CustomService customService;
+
+    @PostMapping("/update-custom")
+    public String updateAiSettings(
+        @ModelAttribute("aiForm")   SettingAiForm settingAiForm,
+        Authentication authentication,
+        BindingResult bindingResult,
+        RedirectAttributes redirectAttributes
+    ) {
+        if (bindingResult.hasErrors()) {
+            redirectAttributes.addFlashAttribute("errors", bindingResult.getAllErrors());
+            return "redirect:/app/settings/ai";
+        }
+
+        String userId = authentication.getName();
+
+        boolean isSuccess = customService.updateCustom(userId, new CustomAIDto(
+            settingAiForm.getSelectedAiId(), settingAiForm.isFormal(), settingAiForm.isLong()
+        ));
+        if (!isSuccess) {
+            redirectAttributes.addFlashAttribute("message", "AI 설정 도중 문제가 발생하였습니다");
+            return "redirect:/app/settings/ai";
+        }
+
+        redirectAttributes.addFlashAttribute("message", "성공적으로 AI 설정을 변경하였습니다");
+        return "redirect:/app/settings";
+    }
+}

--- a/src/main/java/com/grepp/diary/app/controller/web/custom/form/SettingAiForm.java
+++ b/src/main/java/com/grepp/diary/app/controller/web/custom/form/SettingAiForm.java
@@ -1,0 +1,11 @@
+package com.grepp.diary.app.controller.web.custom.form;
+
+import lombok.Data;
+
+@Data
+public class SettingAiForm {
+
+    private Integer selectedAiId;
+    private boolean isFormal;
+    private boolean isLong;
+}

--- a/src/main/java/com/grepp/diary/app/model/ai/AiService.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/AiService.java
@@ -1,6 +1,7 @@
 package com.grepp.diary.app.model.ai;
 
 import com.grepp.diary.app.controller.api.admin.payload.AdminAiWriteRequest;
+import com.grepp.diary.app.model.ai.dto.AiInfoDto;
 import com.grepp.diary.app.model.ai.dto.AiDto;
 import com.grepp.diary.app.model.ai.entity.Ai;
 import com.grepp.diary.app.model.ai.repository.AiRepository;
@@ -74,5 +75,10 @@ public class AiService {
         aiRepository.save(ai);
 
         return true;
+    }
+
+    /** 모든 AI에 대한 정보를 반환합니다.(프롬프트 제외) */
+    public List<AiInfoDto> getAIList() {
+        return aiRepository.getAIListDto();
     }
 }

--- a/src/main/java/com/grepp/diary/app/model/ai/dto/AiInfoDto.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/dto/AiInfoDto.java
@@ -1,0 +1,20 @@
+package com.grepp.diary.app.model.ai.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter @Setter
+public class AiInfoDto {
+
+    private Integer aiId;
+    private String name;
+    private String mbti;
+    private String info;
+    private String imgUrl;
+}

--- a/src/main/java/com/grepp/diary/app/model/ai/repository/AIRepositoryCustom.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/repository/AIRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.grepp.diary.app.model.ai.repository;
+
+import com.grepp.diary.app.model.ai.dto.AiInfoDto;
+import java.util.List;
+
+public interface AIRepositoryCustom {
+
+    List<AiInfoDto> getAIListDto();
+}

--- a/src/main/java/com/grepp/diary/app/model/ai/repository/AIRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/repository/AIRepositoryCustomImpl.java
@@ -1,0 +1,37 @@
+package com.grepp.diary.app.model.ai.repository;
+
+import com.grepp.diary.app.model.ai.dto.AiInfoDto;
+import com.grepp.diary.app.model.ai.entity.QAi;
+import com.grepp.diary.app.model.ai.entity.QAiImg;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AIRepositoryCustomImpl implements AIRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    QAi ai = QAi.ai;
+    QAiImg aiImg = QAiImg.aiImg;
+
+    @Override
+    public List<AiInfoDto> getAIListDto() {
+        return queryFactory
+            .select(Projections.constructor(
+                AiInfoDto.class,
+                ai.aiId,
+                ai.name,
+                ai.mbti,
+                ai.info,
+                aiImg.savePath
+            ))
+            .from(ai)
+            .leftJoin(aiImg)
+            .on(ai.aiId.eq(aiImg.ai.aiId))
+            .where(ai.isUse.isTrue())
+            .fetch();
+    }
+}

--- a/src/main/java/com/grepp/diary/app/model/ai/repository/AiRepository.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/repository/AiRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AiRepository extends JpaRepository<Ai, Integer> {
+public interface AiRepository extends JpaRepository<Ai, Integer>, AIRepositoryCustom {
 
 }

--- a/src/main/java/com/grepp/diary/app/model/custom/CustomService.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/CustomService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -47,6 +48,11 @@ public class CustomService {
     }
 
     public CustomAIDto getCustomAiByUserId(String id) {
-        return customRepository.getCustomAiByUserId(id);
+        return customRepository.getCustomByUserId(id);
+    }
+
+    @Transactional
+    public boolean updateCustom(String userId, CustomAIDto customAIDto) {
+        return customRepository.updateCustomByUserId(userId, customAIDto) > 0;
     }
 }

--- a/src/main/java/com/grepp/diary/app/model/custom/CustomService.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/CustomService.java
@@ -2,6 +2,7 @@ package com.grepp.diary.app.model.custom;
 
 import com.grepp.diary.app.model.ai.dto.AiAdminDto;
 import com.grepp.diary.app.model.ai.entity.Ai;
+import com.grepp.diary.app.model.custom.dto.CustomAIDto;
 import com.grepp.diary.app.model.custom.entity.Custom;
 import com.grepp.diary.app.model.custom.repository.CustomRepository;
 import com.querydsl.core.Tuple;
@@ -22,7 +23,7 @@ public class CustomService {
     private final ModelMapper mapper;
 
     public Optional<Custom> findByUserId(String userId) {
-        return customRepository.findByMember_UserId(userId);
+        return customRepository.findByMemberUserId(userId);
     }
 
     public List<AiAdminDto> getAiByLimit(Integer limit) {
@@ -43,5 +44,9 @@ public class CustomService {
 
     public void save(Custom custom) {
         customRepository.save(custom);
+    }
+
+    public CustomAIDto getCustomAiByUserId(String id) {
+        return customRepository.getCustomAiByUserId(id);
     }
 }

--- a/src/main/java/com/grepp/diary/app/model/custom/dto/CustomAIDto.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/dto/CustomAIDto.java
@@ -1,0 +1,16 @@
+package com.grepp.diary.app.model.custom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Data
+@Getter @Setter
+@AllArgsConstructor
+public class CustomAIDto {
+
+    private String name;
+    private boolean isFormal;
+    private boolean isLong;
+}

--- a/src/main/java/com/grepp/diary/app/model/custom/dto/CustomAIDto.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/dto/CustomAIDto.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class CustomAIDto {
 
-    private String name;
+    private Integer aiId;
     private boolean isFormal;
     private boolean isLong;
 }

--- a/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepository.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CustomRepository extends JpaRepository<Custom, Integer>, CustomRepositoryCustom {
 
-    Optional<Custom> findByMember_UserId(String userId);
+    Optional<Custom> findByMemberUserId(String userId);
 }

--- a/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepositoryCustom.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepositoryCustom.java
@@ -1,9 +1,11 @@
 package com.grepp.diary.app.model.custom.repository;
 
+import com.grepp.diary.app.model.custom.dto.CustomAIDto;
 import com.querydsl.core.Tuple;
 import java.util.List;
 
 public interface CustomRepositoryCustom {
     List<Tuple> getAiByLimit(Integer limit);
+    CustomAIDto getCustomAiByUserId(String id);
 }
 

--- a/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepositoryCustom.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepositoryCustom.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public interface CustomRepositoryCustom {
     List<Tuple> getAiByLimit(Integer limit);
-    CustomAIDto getCustomAiByUserId(String id);
+    CustomAIDto getCustomByUserId(String id);
+    int updateCustomByUserId(String userId, CustomAIDto customAIDto);
 }
 

--- a/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepositoryImpl.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepositoryImpl.java
@@ -1,13 +1,17 @@
 package com.grepp.diary.app.model.custom.repository;
 
 import com.grepp.diary.app.model.ai.entity.QAi;
+import com.grepp.diary.app.model.custom.dto.CustomAIDto;
 import com.grepp.diary.app.model.custom.entity.QCustom;
+import com.grepp.diary.app.model.member.entity.QMember;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,6 +22,7 @@ public class CustomRepositoryImpl implements CustomRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final QAi ai = QAi.ai;
     private final QCustom custom = QCustom.custom;
+    private final QMember member = QMember.member;
 
     @Override
     public List<Tuple> getAiByLimit(Integer limit) {
@@ -35,5 +40,21 @@ public class CustomRepositoryImpl implements CustomRepositoryCustom {
         }
 
         return query.fetch();
+    }
+
+    @Override
+    public CustomAIDto getCustomAiByUserId(String userId) {
+        return queryFactory
+            .select(Projections.constructor(
+                CustomAIDto.class,
+                ai.name,
+                custom.isFormal,
+                custom.isLong
+            ))
+            .from(custom)
+            .leftJoin(ai).on(custom.ai.aiId.eq(ai.aiId))
+            .where(custom.member.userId.eq(userId))
+            .fetchOne();
+
     }
 }

--- a/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepositoryImpl.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/repository/CustomRepositoryImpl.java
@@ -22,7 +22,6 @@ public class CustomRepositoryImpl implements CustomRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final QAi ai = QAi.ai;
     private final QCustom custom = QCustom.custom;
-    private final QMember member = QMember.member;
 
     @Override
     public List<Tuple> getAiByLimit(Integer limit) {
@@ -43,18 +42,28 @@ public class CustomRepositoryImpl implements CustomRepositoryCustom {
     }
 
     @Override
-    public CustomAIDto getCustomAiByUserId(String userId) {
+    public CustomAIDto getCustomByUserId(String userId) {
         return queryFactory
             .select(Projections.constructor(
                 CustomAIDto.class,
-                ai.name,
+                custom.ai.aiId,
                 custom.isFormal,
                 custom.isLong
             ))
             .from(custom)
-            .leftJoin(ai).on(custom.ai.aiId.eq(ai.aiId))
             .where(custom.member.userId.eq(userId))
             .fetchOne();
 
+    }
+
+    @Override
+    public int updateCustomByUserId(String userId, CustomAIDto customAIDto) {
+        long updated = queryFactory
+            .update(custom)
+            .set(custom.ai.aiId, customAIDto.getAiId())
+            .set(custom.isFormal, customAIDto.isFormal())
+            .set(custom.isLong, customAIDto.isLong())
+            .where(custom.member.userId.eq(userId)).execute();
+        return (int) updated;
     }
 }

--- a/src/main/java/com/grepp/diary/infra/config/SecurityConfig.java
+++ b/src/main/java/com/grepp/diary/infra/config/SecurityConfig.java
@@ -57,8 +57,9 @@ public class SecurityConfig {
                 .userDetailsService(userDetailsService))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(GET, "/", "/css/**", "/js/**", "/images/**", "/assets/**").permitAll()
-                    .requestMatchers("/member/login", "/member/logout", "/member/find_id", "/member/find_pw", "/member/regist/**", "/member/regist-mail","/member/auth-id","/member/auth-pw").permitAll()
-                    .requestMatchers("/member/auth-id", "/member/auth-pw", "/member/change-pw", "/member/find-idpw").permitAll()
+                .requestMatchers("/member/login", "/member/logout", "/member/find_id", "/member/find_pw", "/member/regist/**", "/member/regist-mail","/member/auth-id","/member/auth-pw").permitAll()
+                .requestMatchers("/member/auth-id", "/member/auth-pw", "/member/change-pw", "/member/find-idpw").permitAll()
+                .requestMatchers("/custom/**").permitAll()
 //                .anyRequest().permitAll() // 개발 중 전체 열기
                 .anyRequest().authenticated()
             );

--- a/src/main/resources/static/css/card-list.css
+++ b/src/main/resources/static/css/card-list.css
@@ -38,7 +38,7 @@
   border-radius: 12px;
   overflow: hidden;
   position: relative;
-  border: 1px solid transparent;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
 /* 왼쪽 이모지 + 날짜 */
@@ -104,7 +104,6 @@
 .diary-card.no-image {
   background-color: #FEFBF6;
   color: #282420;
-  border-color: #282420;
 }
 
 /* 숨김 이미지용 요소 */

--- a/src/main/resources/static/css/settings.css
+++ b/src/main/resources/static/css/settings.css
@@ -14,6 +14,7 @@
   padding-top: 30px;
   padding-left: 30px;
   margin-bottom: 10px;
+  align-content: center;
 }
 
 .bento-btn {
@@ -118,6 +119,172 @@
 
 .alert-banner i {
   font-size: 1rem;
+}
+
+/****************/
+/*   AI CARDS   */
+/****************/
+.ai-card-container {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+  padding: 0 30px;
+}
+
+.ai-card {
+  border: 1px solid #ADAB9F;
+  border-radius: 12px;
+  padding: 24px;
+  text-align: center;
+  transition: 0.2s ease;
+}
+
+.ai-card.selected {
+  border: 1px solid #467750;
+  background-color: #f3f8f4;
+}
+
+.ai-image {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background-color: #ADAB9F;
+  margin: 0 auto 16px;
+}
+
+.ai-name {
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+.ai-mbti {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.ai-info {
+  font-size: 0.85rem;
+  color: #777;
+  margin-top: 8px;
+}
+
+.select-button {
+  margin-top: 12px;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  background-color: #D9D8D5;
+  color: #333;
+}
+
+.select-button.selected {
+  background-color: #467750;
+  color: white;
+}
+
+/****************/
+/* radio button */
+/****************/
+.bento-radio-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 30px;
+  padding-left: 30px;
+  padding-right: 30px;
+  margin-bottom: 10px;
+}
+
+.bento-radio-wrapper .bento-title {
+  margin-bottom: 0;
+  padding: 0;
+  font-size: 1.5rem;
+  color: #282420;
+  white-space: nowrap;
+}
+
+.tone-options,
+.length-options {
+  width: 250px;
+  display: flex;
+  justify-content: space-between;
+  gap: 30px;
+  padding: 0;
+  margin: 0;
+}
+
+.radio-label {
+  width: 100px;
+  display: inline-block;
+  margin-right: 20px;
+  cursor: pointer;
+}
+
+.radio-hidden {
+  display: none;
+}
+
+.radio-hidden:checked + .radio-button {
+  border-color: #467750;
+  background-color: #467750;
+  color: #fff;
+  font-weight: bold;
+}
+
+/* 라디오 버튼 영역 전체를 감싸는 박스 */
+.radio-btn-box {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px; /* 버튼과 텍스트 간격 */
+  padding: 10px 0;
+  color: #282420;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+/* 내부 라디오 박스 */
+.radio-button {
+  width: 20px;
+  height: 20px;
+  border-radius: 2px;
+  border: 2px solid #467750;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.radio-button i {
+  display: none;
+  color: white;
+  font-size: 0.8rem;
+  line-height: 20px;
+  text-align: center;
+  width: 100%;
+}
+
+
+/* 체크된 버튼 스타일 */
+.radio-hidden:checked + .radio-btn-box {
+  border-color: #467750;
+  color: #282420;
+}
+
+.radio-hidden:checked + .radio-btn-box .radio-button i {
+  display: block;
+}
+
+/* 체크됐을 때 내부 색상 */
+.radio-hidden:checked + .radio-btn-box .radio-button {
+  background-color: #467750;
+  box-shadow: inset 0 0 0 6px #467750;
+}
+
+/* 텍스트 */
+.radio-text {
+  font-size: 0.95rem;
 }
 
 /* leave */

--- a/src/main/resources/static/js/calendar.js
+++ b/src/main/resources/static/js/calendar.js
@@ -103,8 +103,8 @@ async function fetchEmotionData(year, month) {
   const data = await response.json();
 
   const emotionMap = {};
-  data.diaryEmotions.forEach(({ createdAt, emotion }) => {
-    emotionMap[createdAt] = emotion;
+  data.diaryEmotions.forEach(({ diaryDate, emotion }) => {
+    emotionMap[diaryDate] = emotion;
   });
 
   renderCalendar(new Date(year, month - 1), emotionMap);

--- a/src/main/resources/static/js/card-list.js
+++ b/src/main/resources/static/js/card-list.js
@@ -32,6 +32,12 @@ async function loadRecentDiaries(userId) {
     const right = clone.querySelector(".diary-right");
     right.textContent = diary.content || "(내용 없음)";
 
+    // 상세 페이지로 이동 이벤트 추가
+    card.addEventListener("click", () => {
+      const dateParam = diary.date;
+      window.location.href = `/diary/record?date=${dateParam}`;
+    });
+
     container.appendChild(clone);
   });
 }

--- a/src/main/resources/static/js/card-timeline.js
+++ b/src/main/resources/static/js/card-timeline.js
@@ -72,5 +72,11 @@ function renderDiaryCard(diary) {
     img.src = diary.imagePath;
   }
 
+  // 상세 페이지로 이동 이벤트 추가
+  card.addEventListener("click", () => {
+    const dateParam = diary.date;
+    window.location.href = `/diary/record?date=${dateParam}`;
+  });
+
   return clone;
 }

--- a/src/main/resources/static/js/settings.js
+++ b/src/main/resources/static/js/settings.js
@@ -56,5 +56,37 @@ document.addEventListener("DOMContentLoaded", () => {
       card.appendChild(button);
       container.appendChild(card);
     });
+
+    return fetch("/api/custom")
+  })
+  .then(res => res.json())
+  .then(setting => {
+    // AI 카드 중 이름이 일치하는 카드 선택
+    const cards = container.querySelectorAll(".ai-card");
+    cards.forEach(card => {
+      const name = card.querySelector(".ai-name")?.textContent?.trim();
+      const button = card.querySelector(".select-button");
+      if (name === setting.name) {
+        card.classList.add("selected");
+        button.classList.add("selected");
+        button.innerHTML = `<i class="fa-solid fa-check"></i> 선택됨`;
+        selectedInput.value = setting.name; // 또는 ai.id로 매칭되도록 조정 필요
+        currentSelectedCard = card;
+      }
+    });
+
+    // 말투 설정 (tone)
+    const toneRadios = document.querySelectorAll('input[name="tone"]');
+    toneRadios.forEach(radio => {
+      radio.checked = (setting.isFormal && radio.value === "formal") ||
+          (!setting.isFormal && radio.value === "friendly");
+    });
+
+    // 답변 길이 설정 (length)
+    const lengthRadios = document.querySelectorAll('input[name="length"]');
+    lengthRadios.forEach(radio => {
+      radio.checked = (setting.isLong && radio.value === "long") ||
+          (!setting.isLong && radio.value === "short");
+    });
   });
 });

--- a/src/main/resources/static/js/settings.js
+++ b/src/main/resources/static/js/settings.js
@@ -6,11 +6,12 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("aiForm").appendChild(selectedInput);
 
   let currentSelectedCard = null;
+  let aiList = [];
 
   fetch("/api/ai/list")
   .then(response => response.json())
   .then(data => {
-    const aiList = data.aiInfoList;
+    aiList = data.aiInfoList;
 
     aiList.forEach((ai, index) => {
       const card = document.createElement("div");
@@ -55,38 +56,43 @@ document.addEventListener("DOMContentLoaded", () => {
         `;
       card.appendChild(button);
       container.appendChild(card);
+      card.setAttribute("data-ai-id", ai.id);
     });
 
     return fetch("/api/custom")
   })
   .then(res => res.json())
   .then(setting => {
+    selectedInput.value = setting.aiId;
     // AI 카드 중 이름이 일치하는 카드 선택
     const cards = container.querySelectorAll(".ai-card");
     cards.forEach(card => {
-      const name = card.querySelector(".ai-name")?.textContent?.trim();
       const button = card.querySelector(".select-button");
-      if (name === setting.name) {
+      const aiId = parseInt(card.getAttribute("data-ai-id"), 10);
+      if (aiId === setting.aiId) {
         card.classList.add("selected");
         button.classList.add("selected");
         button.innerHTML = `<i class="fa-solid fa-check"></i> 선택됨`;
-        selectedInput.value = setting.name; // 또는 ai.id로 매칭되도록 조정 필요
+        const matchedAi = aiList.find(ai => ai.name === setting.name);
+        if (matchedAi) {
+          selectedInput.value = matchedAi.id;
+        }
         currentSelectedCard = card;
       }
     });
 
     // 말투 설정 (tone)
-    const toneRadios = document.querySelectorAll('input[name="tone"]');
+    const toneRadios = document.querySelectorAll('input[name="isFormal"]');
     toneRadios.forEach(radio => {
-      radio.checked = (setting.isFormal && radio.value === "formal") ||
-          (!setting.isFormal && radio.value === "friendly");
+      radio.checked = (setting.isFormal && radio.value === "true") ||
+          (!setting.isFormal && radio.value === "false");
     });
 
     // 답변 길이 설정 (length)
-    const lengthRadios = document.querySelectorAll('input[name="length"]');
+    const lengthRadios = document.querySelectorAll('input[name="isLong"]');
     lengthRadios.forEach(radio => {
-      radio.checked = (setting.isLong && radio.value === "long") ||
-          (!setting.isLong && radio.value === "short");
+      radio.checked = (setting.isLong && radio.value === "true") ||
+          (!setting.isLong && radio.value === "false");
     });
   });
 });

--- a/src/main/resources/static/js/settings.js
+++ b/src/main/resources/static/js/settings.js
@@ -1,0 +1,60 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const container = document.getElementById("ai-card-container");
+  const selectedInput = document.createElement("input");
+  selectedInput.type = "hidden";
+  selectedInput.name = "selectedAiId";
+  document.getElementById("aiForm").appendChild(selectedInput);
+
+  let currentSelectedCard = null;
+
+  fetch("/api/ai/list")
+  .then(response => response.json())
+  .then(data => {
+    const aiList = data.aiInfoList;
+
+    aiList.forEach((ai, index) => {
+      const card = document.createElement("div");
+      card.classList.add("ai-card");
+
+      const button = document.createElement("button");
+      button.classList.add("select-button");
+      button.textContent = "선택";
+
+      button.addEventListener("click", (e) => {
+        e.preventDefault();
+
+        // 이전 선택 해제
+        if (currentSelectedCard) {
+          currentSelectedCard.classList.remove("selected");
+          const oldBtn = currentSelectedCard.querySelector(".select-button");
+          oldBtn.textContent = "선택";
+          oldBtn.classList.remove("selected");
+          const oldIcon = oldBtn.querySelector("i");
+          if (oldIcon) oldIcon.remove();
+        }
+
+        // 새로운 선택 표시
+        card.classList.add("selected");
+        button.classList.add("selected");
+        button.textContent = "";
+        const checkIcon = document.createElement("i");
+        checkIcon.className = "fa-solid fa-check";
+        button.appendChild(checkIcon);
+        button.appendChild(document.createTextNode(" 선택됨"));
+
+        // 선택 상태 저장
+        currentSelectedCard = card;
+        selectedInput.value = ai.id;
+      });
+
+      card.innerHTML = `
+          <div class="ai-image"></div>
+          <div class="ai-name">${ai.name}</div>
+          <div class="ai-mbti">${ai.mbti}</div>
+          <div class="ai-info">${ai.info}</div>
+        `;
+      card.appendChild(button);
+      container.appendChild(card);
+    });
+  });
+});

--- a/src/main/resources/templates/app/settings/settings-ai.html
+++ b/src/main/resources/templates/app/settings/settings-ai.html
@@ -17,19 +17,64 @@
 
   <div class="main">
     <div class="main-container">
-      <div class="setting-bento">
-        <div class="bento-title">AI 캐릭터 선택</div>
-      </div>
-      <div class="setting-bento">
-        <div class="bento-title">말투 설정</div>
-      </div>
-      <div class="setting-bento">
-        <div class="bento-title">답변 길이 설정</div>
+      <form id="aiForm" action="ai/settings/ai" method="post">
+        <div class="setting-bento">
+          <div class="bento-title">AI 캐릭터 선택</div>
+          <div id="ai-card-container" class="ai-card-container"></div>
+        </div>
+        <div class="setting-bento">
+          <div class="bento-radio-wrapper">
+            <div class="bento-title">말투 설정</div>
+            <div class="tone-options bento-radio">
+              <label class="radio-label">
+                <input type="radio" name="tone" value="friendly" class="radio-hidden" checked>
+                <div class="radio-btn-box">
+                  <div class="radio-button"> <i class="fa-solid fa-check"></i></div>
+                  <span class="radio-text">친근하게</span>
+                </div>
+              </label>
+              <label class="radio-label">
+                <input type="radio" name="tone" value="formal" class="radio-hidden">
+                <div class="radio-btn-box">
+                  <div class="radio-button"> <i class="fa-solid fa-check"></i></div>
+                  <span class="radio-text">정중하게</span>
+                </div>
+              </label>
+            </div>
+          </div>
+
+
+        </div>
+        <div class="setting-bento">
+          <div class="bento-radio-wrapper">
+            <div class="bento-title">답변 길이 설정</div>
+            <div class="length-options bento-radio">
+              <label class="radio-label">
+                <input type="radio" name="length" value="short" class="radio-hidden" checked>
+                <div class="radio-btn-box">
+                  <div class="radio-button"> <i class="fa-solid fa-check"></i></div>
+                  <span class="radio-text">짧은 답변</span>
+                </div>
+              </label>
+              <label class="radio-label">
+                <input type="radio" name="length" value="long" class="radio-hidden">
+                <div class="radio-btn-box">
+                  <div class="radio-button"> <i class="fa-solid fa-check"></i></div>
+                  <span class="radio-text">긴 답변</span>
+                </div>
+              </label>
+            </div>
+          </div>
+        </div>
+      </form>
+      <div class="button-wrapper">
+        <button type="submit" class="confirm-btn" form="aiForm">저장하기</button>
       </div>
     </div>
   </div>
 
   <script src="/js/sidebar.js"></script>
+  <script src="/js/settings.js"></script>
   <script src="/js/logout.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/app/settings/settings-ai.html
+++ b/src/main/resources/templates/app/settings/settings-ai.html
@@ -17,7 +17,8 @@
 
   <div class="main">
     <div class="main-container">
-      <form id="aiForm" action="ai/settings/ai" method="post">
+      <form id="aiForm" action="/custom/update-custom" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <div class="setting-bento">
           <div class="bento-title">AI 캐릭터 선택</div>
           <div id="ai-card-container" class="ai-card-container"></div>
@@ -27,14 +28,14 @@
             <div class="bento-title">말투 설정</div>
             <div class="tone-options bento-radio">
               <label class="radio-label">
-                <input type="radio" name="tone" value="friendly" class="radio-hidden" checked>
+                <input type="radio" name="isFormal" value="false" class="radio-hidden" checked>
                 <div class="radio-btn-box">
                   <div class="radio-button"> <i class="fa-solid fa-check"></i></div>
                   <span class="radio-text">친근하게</span>
                 </div>
               </label>
               <label class="radio-label">
-                <input type="radio" name="tone" value="formal" class="radio-hidden">
+                <input type="radio" name="isFormal" value="true" class="radio-hidden">
                 <div class="radio-btn-box">
                   <div class="radio-button"> <i class="fa-solid fa-check"></i></div>
                   <span class="radio-text">정중하게</span>
@@ -50,14 +51,14 @@
             <div class="bento-title">답변 길이 설정</div>
             <div class="length-options bento-radio">
               <label class="radio-label">
-                <input type="radio" name="length" value="short" class="radio-hidden" checked>
+                <input type="radio" name="isLong" value="false" class="radio-hidden" checked>
                 <div class="radio-btn-box">
                   <div class="radio-button"> <i class="fa-solid fa-check"></i></div>
                   <span class="radio-text">짧은 답변</span>
                 </div>
               </label>
               <label class="radio-label">
-                <input type="radio" name="length" value="long" class="radio-hidden">
+                <input type="radio" name="isLong" value="true" class="radio-hidden">
                 <div class="radio-btn-box">
                   <div class="radio-button"> <i class="fa-solid fa-check"></i></div>
                   <span class="radio-text">긴 답변</span>


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 설명
- 카드 클릭시 해당 카드의 일기를 조회하는 기능 추가
- 약간의 UI 개선
- AI 설정 페이지 기능 구현 완료

## 👩‍💻 구현 내용
### ✨ Feat: Navigate to detail page on card click
- 카드클릭시 해당 카드의 일기조회 페이지로 이동합니다.
- 타임라인과 최근 할목에 모두 적용됩니다.

### ♻️ Refactor: Add diary date field to response DTO
- diary reponse 에 date필드가 없는 문제를 해결하였습니다.

### 💄 Add shadows to diary card on home
- 최근 항목에서의 카드 페이지를 개선하였습니다.
- 테두리를 제거하였고, 그림자를 추가하였습니다.

### 이후의 모든 commit
- AI 설정 페이지의 UI를 완성하였습니다.
- AI 설정 페이지의 모든 기능을 구현하였습니다.

