### PR TITLE
UI & API Changes

### DIFF
--- a/src/main/java/com/grepp/diary/app/controller/api/admin/AdminApiController.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/admin/AdminApiController.java
@@ -8,12 +8,14 @@ import com.grepp.diary.app.controller.api.admin.payload.AdminKeywordResponse;
 import com.grepp.diary.app.controller.api.admin.payload.AdminKeywordWriteRequest;
 import com.grepp.diary.app.model.ai.AiService;
 import com.grepp.diary.app.model.ai.dto.AiDto;
+import com.grepp.diary.app.model.ai.entity.Ai;
 import com.grepp.diary.app.model.custom.CustomService;
 import com.grepp.diary.app.model.keyword.KeywordService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -114,18 +116,18 @@ public class AdminApiController {
 
     @PatchMapping("ai/modify")
     public Boolean modifyAi(
-        @RequestBody AdminAiWriteRequest adminAiWriteRequest
+        @ModelAttribute AdminAiWriteRequest request
     ) {
-        aiService.modifyAi(adminAiWriteRequest);
+        aiService.modifyAi(request.getImages(), request);
 
         return true;
     }
 
     @PostMapping("ai")
     public Boolean createAi(
-        @RequestBody AdminAiWriteRequest adminAiWriteRequest
+        @ModelAttribute AdminAiWriteRequest request
     ) {
-        aiService.createAi(adminAiWriteRequest);
+        aiService.createAi(request.getImages(), request);
 
         return true;
     }

--- a/src/main/java/com/grepp/diary/app/controller/api/admin/payload/AdminAiResponse.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/admin/payload/AdminAiResponse.java
@@ -1,6 +1,6 @@
 package com.grepp.diary.app.controller.api.admin.payload;
 
-import com.grepp.diary.app.model.ai.dto.AiAdminDto;
+import com.grepp.diary.app.model.ai.dto.AiWithCountDto;
 import java.util.List;
 
 public record AdminAiResponse(
@@ -15,20 +15,20 @@ public record AdminAiResponse(
         Boolean isUse,
         Integer count
     ) {
-        public static AiInfo fromDto(AiAdminDto aiAdminDto) {
+        public static AiInfo fromDto(AiWithCountDto aiWithCountDto) {
             return new AiInfo(
-                aiAdminDto.getAiId(),
-                aiAdminDto.getName(),
-                aiAdminDto.getMbti(),
-                aiAdminDto.getInfo(),
-                aiAdminDto.getPrompt(),
-                aiAdminDto.getIsUse(),
-                aiAdminDto.getCount()
+                aiWithCountDto.getAiId(),
+                aiWithCountDto.getName(),
+                aiWithCountDto.getMbti(),
+                aiWithCountDto.getInfo(),
+                aiWithCountDto.getPrompt(),
+                aiWithCountDto.getIsUse(),
+                aiWithCountDto.getCount()
             );
         }
     }
 
-    public static AdminAiResponse fromDtoList(List<AiAdminDto> ais) {
+    public static AdminAiResponse fromDtoList(List<AiWithCountDto> ais) {
         List<AiInfo> aiInfos = ais.stream().map(AiInfo::fromDto).toList();
         return new AdminAiResponse(aiInfos);
     }

--- a/src/main/java/com/grepp/diary/app/controller/api/admin/payload/AdminAiWriteRequest.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/admin/payload/AdminAiWriteRequest.java
@@ -1,18 +1,24 @@
 package com.grepp.diary.app.controller.api.admin.payload;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
 public class AdminAiWriteRequest {
     private Integer id;
     private String name;
     private String mbti;
     private String info;
     private String prompt;
+
+    private List<MultipartFile> images;
 }

--- a/src/main/java/com/grepp/diary/app/controller/api/diary/DiaryApiController.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/diary/DiaryApiController.java
@@ -17,6 +17,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -35,16 +36,16 @@ public class DiaryApiController {
     private final DiaryService diaryService;
     private final DateUtil dateUtil;
 
-
-    //TODO : Auth 구현되면 @AuthnticationPrincipal CustomUserDetails user 로 변경 할 것
     @GetMapping("/calendar")
     public DiaryCalendarResponse getEmotionsForCalendar(
-        @RequestParam String userId,
+        Authentication authentication,
         @RequestParam int year,
         @RequestParam int month
     ) {
         LocalDate start = LocalDate.of(year, month, 1);
         LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        String userId = authentication.getName();
 
         return DiaryCalendarResponse.fromEntityList(
             diaryService.getDiariesDateBetween(userId, start, end)
@@ -54,10 +55,12 @@ public class DiaryApiController {
     //TODO : Auth 구현되면 @AuthnticationPrincipal CustomUserDetails user 로 변경 할 것
     @GetMapping("/cards")
     public DiaryCardResponse getDiaryCards( // 기본적으로는 최근 작성된 14개의 일기를 가져옵니다.
-        @RequestParam String userId,
+        Authentication authentication,
         @RequestParam(defaultValue="0") int page,
         @RequestParam(defaultValue = "14") int size
     ) {
+        String userId = authentication.getName();
+
         return DiaryCardResponse.fromEntityList(
             diaryService.getDiariesWithImages(userId, page, size)
         );
@@ -66,13 +69,14 @@ public class DiaryApiController {
     // 월간/연간 작성된 일기수 데이터 API
     @GetMapping("/dashboard/count")
     public int getDiaryCount(
-        @RequestParam String userId,
+        Authentication authentication,
         @RequestParam String period,
         @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate date
     ){
         DateRangeDto range = dateUtil.toDateRangeDto(period, date);
         LocalDate start = range.start();
         LocalDate end = range.end();
+        String userId = authentication.getName();
 
         return diaryService.getUserDiaryCount(userId, start, end);
     }
@@ -80,12 +84,13 @@ public class DiaryApiController {
     // 기분 흐름 데이터(월간) API
     @GetMapping("/emotion/flow/monthly")
     public DiaryDailyEmotionResponse getEmotionFlow(
-        @RequestParam String userId,
+        Authentication authentication,
         @RequestParam(required = false) LocalDate date
     ) {
         DateRangeDto range = dateUtil.toDateRangeDto("monthly", date);
         LocalDate start = range.start();
         LocalDate end = range.end();
+        String userId = authentication.getName();
 
         return DiaryDailyEmotionResponse.fromEntityList(
             diaryService.getDiariesDateBetween(userId, start, end)
@@ -96,9 +101,11 @@ public class DiaryApiController {
     // 기분 흐름 데이터(연간) API
     @GetMapping("/emotion/flow/yearly")
     public DiaryMonthlyEmotionResponse getMonthlyEmotionAvg(
-        @RequestParam String userId,
+        Authentication authentication,
         @RequestParam(required = false) int year
     ) {
+        String userId = authentication.getName();
+
         return DiaryMonthlyEmotionResponse.fromDtoList(
             diaryService.getMonthlyEmotionAvgOfYear(userId, year)
         );
@@ -107,10 +114,11 @@ public class DiaryApiController {
     // 특정 날에 대한 일기 유무 API
     @GetMapping("/check")
     public boolean checkDiaryOfDay(
-        @RequestParam String userId,
+        Authentication authentication,
         @RequestParam LocalDate date
     ) {
         LocalDate nextDate = date.plusDays(1);
+        String userId = authentication.getName();
 
         return !diaryService.getDiariesDateBetween(userId, date, nextDate).isEmpty();
     }
@@ -151,10 +159,12 @@ public class DiaryApiController {
     // 특정 기간내의 작성된 일기 기준 감정별 개수 API
     @GetMapping("/emotion/count")
     public DiaryEmotionCountResponse getEmotionCount(
-        @RequestParam String userId,
+        Authentication authentication,
         @RequestParam String period,
         @RequestParam int value
     ) {
+        String userId = authentication.getName();
+
         return DiaryEmotionCountResponse.fromDtoList(
             diaryService.getEmotionsCount(userId, period, value)
         );

--- a/src/main/java/com/grepp/diary/app/controller/api/diary/payload/DiaryDailyEmotionResponse.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/diary/payload/DiaryDailyEmotionResponse.java
@@ -14,7 +14,7 @@ public record DiaryDailyEmotionResponse(
     ) {
         public static DiaryDailyEmotion fromEntity(Diary diary) {
             return new DiaryDailyEmotion(
-                diary.getCreatedAt().toLocalDate(),
+                diary.getDate(),
                 diary.getEmotion()
             );
         }

--- a/src/main/java/com/grepp/diary/app/controller/api/keyword/KeywordApiController.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/keyword/KeywordApiController.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,13 +23,14 @@ public class KeywordApiController {
 
     @GetMapping("/ranking")
     public KeywordRankResponse getKeywordRanking(
-        @RequestParam String userId,
+        Authentication authentication,
         @RequestParam String period,
         @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate date
     ) {
         DateRangeDto range = dateUtil.toDateRangeDto(period, date);
         LocalDate start = range.start();
         LocalDate end = range.end();
+        String userId = authentication.getName();
 
         return KeywordRankResponse.fromDtoList(keywordService.getTop5Keywords(userId, start, end));
     }

--- a/src/main/java/com/grepp/diary/app/controller/web/admin/AdminController.java
+++ b/src/main/java/com/grepp/diary/app/controller/web/admin/AdminController.java
@@ -1,6 +1,6 @@
 package com.grepp.diary.app.controller.web.admin;
 
-import com.grepp.diary.app.model.ai.dto.AiAdminDto;
+import com.grepp.diary.app.model.ai.dto.AiWithCountDto;
 import com.grepp.diary.app.model.custom.CustomService;
 import com.grepp.diary.app.model.diary.DiaryService;
 import com.grepp.diary.app.model.keyword.KeywordService;
@@ -30,7 +30,7 @@ public class AdminController {
         List<KeywordAdminDto> popularKeywords = keywordService.getMostPopular();
         Integer memberCount = memberService.getAllMemberCount();
         Integer monthDiaryCount = diaryService.getMonthDiariesCount();
-        List<AiAdminDto> popularCustoms = customService.getAiByLimit(5);
+        List<AiWithCountDto> popularCustoms = customService.getAiByLimit(5);
 
         model.addAttribute("popularKeywords", popularKeywords);
         model.addAttribute("memberCount", memberCount);

--- a/src/main/java/com/grepp/diary/app/model/ai/AiService.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/AiService.java
@@ -4,13 +4,22 @@ import com.grepp.diary.app.controller.api.admin.payload.AdminAiWriteRequest;
 import com.grepp.diary.app.model.ai.dto.AiInfoDto;
 import com.grepp.diary.app.model.ai.dto.AiDto;
 import com.grepp.diary.app.model.ai.entity.Ai;
+import com.grepp.diary.app.model.ai.entity.AiImg;
+import com.grepp.diary.app.model.ai.repository.AiImgRepository;
 import com.grepp.diary.app.model.ai.repository.AiRepository;
+import com.grepp.diary.app.model.common.code.ImgType;
+import com.grepp.diary.infra.error.exceptions.CommonException;
+import com.grepp.diary.infra.response.ResponseCode;
+import com.grepp.diary.infra.util.file.FileDto;
+import com.grepp.diary.infra.util.file.FileUtil;
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AiService {
 
     private final AiRepository aiRepository;
+    private final AiImgRepository aiImgRepository;
+    private final FileUtil fileUtil;
 
     public AiDto getSingleAi(Integer id) {
         Ai ai = aiRepository.findById(id)
@@ -44,37 +55,69 @@ public class AiService {
     }
 
     @Transactional
-    public Boolean modifyAi(AdminAiWriteRequest adminAiWriteRequest) {
-        Optional<Ai> optionalAi = aiRepository.findById(adminAiWriteRequest.getId());
+    public Boolean modifyAi(List<MultipartFile> images, AdminAiWriteRequest request) {
+        try {
 
-        if(optionalAi.isEmpty()) {
-            throw new RuntimeException("Ai not found");
+            Optional<Ai> optionalAi = aiRepository.findById(request.getId());
+
+            if (optionalAi.isEmpty()) {
+                throw new RuntimeException("Ai not found");
+            }
+
+            Ai ai = optionalAi.get();
+            ai.setName(request.getName());
+            ai.setMbti(request.getMbti());
+            ai.setInfo(request.getInfo());
+            ai.setPrompt(request.getPrompt());
+
+            aiRepository.save(ai);
+
+            if (images != null && !images.isEmpty()) {
+                Integer aiId = ai.getAiId();
+                aiImgRepository.makeRestImgFalse(aiId);
+
+                List<FileDto> imageList = fileUtil.upload(images, "ai", ai.getAiId());
+                AiImg aiImg = new AiImg(ImgType.THUMBNAIL, imageList.getFirst());
+
+                aiImg.setAi(ai);
+                aiImg.setIsUse(true);
+
+                aiImgRepository.save(aiImg);
+            }
+
+            return true;
+        } catch (IOException e) {
+            throw new CommonException(ResponseCode.INTERNAL_SERVER_ERROR);
         }
-
-        Ai ai = optionalAi.get();
-        ai.setName(adminAiWriteRequest.getName());
-        ai.setMbti(adminAiWriteRequest.getMbti());
-        ai.setInfo(adminAiWriteRequest.getInfo());
-        ai.setPrompt(adminAiWriteRequest.getPrompt());
-
-        aiRepository.save(ai);
-
-        return true;
     }
 
     @Transactional
-    public Boolean createAi(AdminAiWriteRequest adminAiWriteRequest) {
-        Ai ai = new Ai();
+    public Boolean createAi(List<MultipartFile> images, AdminAiWriteRequest request) {
+        try {
+            Ai ai = new Ai();
 
-        ai.setName(adminAiWriteRequest.getName());
-        ai.setMbti(adminAiWriteRequest.getMbti());
-        ai.setInfo(adminAiWriteRequest.getInfo());
-        ai.setPrompt(adminAiWriteRequest.getPrompt());
-        ai.setIsUse(true);
+            ai.setName(request.getName());
+            ai.setMbti(request.getMbti());
+            ai.setInfo(request.getInfo());
+            ai.setPrompt(request.getPrompt());
+            ai.setIsUse(true);
 
-        aiRepository.save(ai);
+            aiRepository.save(ai);
 
-        return true;
+            if (images.size() > 0) {
+                List<FileDto> imageList = fileUtil.upload(images, "ai", ai.getAiId());
+                AiImg aiImg = new AiImg(ImgType.THUMBNAIL, imageList.getFirst());
+
+                aiImg.setAi(ai);
+                aiImg.setIsUse(true);
+
+                aiImgRepository.save(aiImg);
+            }
+
+            return true;
+        } catch (IOException e) {
+            throw new CommonException(ResponseCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     /** 모든 AI에 대한 정보를 반환합니다.(프롬프트 제외) */

--- a/src/main/java/com/grepp/diary/app/model/ai/dto/AiDto.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/dto/AiDto.java
@@ -1,6 +1,8 @@
 package com.grepp.diary.app.model.ai.dto;
 
 import com.grepp.diary.app.model.ai.entity.Ai;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +15,7 @@ public class AiDto {
     private String info;
     private String prompt;
     private Boolean isUse;
+    private List<AiImgDto> images;
 
     public static AiDto fromEntity(Ai ai) {
         AiDto dto = new AiDto();
@@ -22,6 +25,15 @@ public class AiDto {
         dto.setInfo(ai.getInfo());
         dto.setPrompt(ai.getPrompt());
         dto.setIsUse(ai.getIsUse());
+
+        if (ai.getImages() != null) {
+            List<AiImgDto> imageDtos = ai.getImages().stream()
+                .map(AiImgDto::fromEntity)
+                .toList();
+            dto.setImages(imageDtos);
+        }
+
         return dto;
     }
+
 }

--- a/src/main/java/com/grepp/diary/app/model/ai/dto/AiImgDto.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/dto/AiImgDto.java
@@ -1,0 +1,38 @@
+package com.grepp.diary.app.model.ai.dto;
+
+import com.grepp.diary.app.model.ai.entity.AiImg;
+import com.grepp.diary.app.model.common.code.ImgType;
+import com.grepp.diary.infra.util.file.FileDto;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class AiImgDto {
+
+    private Integer aiImgId;
+    private String savePath;
+    private ImgType type;
+    private String originName;
+    private String renamedName;
+    private Boolean isUSe;
+
+    public AiImgDto(ImgType type, FileDto fileDto) {
+        this.type = type;
+        this.originName = fileDto.originFileName();
+        this.renamedName = fileDto.renameFileName();
+        this.savePath = fileDto.savePath();
+    }
+
+    public static AiImgDto fromEntity(AiImg aiImg) {
+        AiImgDto dto = new AiImgDto();
+        dto.setAiImgId(aiImg.getAiImgId());
+        dto.setSavePath(aiImg.getSavePath());
+        dto.setOriginName(aiImg.getOriginName());
+        dto.setRenamedName(aiImg.getRenamedName());
+        dto.setIsUSe(aiImg.getIsUse());
+        dto.setRenamedName(aiImg.getRenamedPath());
+        dto.setType(aiImg.getType());
+        return dto;
+    }
+}

--- a/src/main/java/com/grepp/diary/app/model/ai/dto/AiImgDto.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/dto/AiImgDto.java
@@ -29,7 +29,6 @@ public class AiImgDto {
         dto.setAiImgId(aiImg.getAiImgId());
         dto.setSavePath(aiImg.getSavePath());
         dto.setOriginName(aiImg.getOriginName());
-        dto.setRenamedName(aiImg.getRenamedName());
         dto.setIsUSe(aiImg.getIsUse());
         dto.setRenamedName(aiImg.getRenamedPath());
         dto.setType(aiImg.getType());

--- a/src/main/java/com/grepp/diary/app/model/ai/dto/AiWithCountDto.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/dto/AiWithCountDto.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class AiAdminDto {
+public class AiWithCountDto {
     private Integer aiId;
     private String name;
     private String mbti;

--- a/src/main/java/com/grepp/diary/app/model/ai/entity/Ai.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/entity/Ai.java
@@ -8,12 +8,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter @Setter
@@ -45,4 +47,8 @@ public class Ai {
 
     @OneToMany(mappedBy = "ai", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Reply> replies = new ArrayList<>();
+
+    @OneToMany(mappedBy = "ai", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Where(clause = "is_use = true")
+    private List<AiImg> images = new ArrayList<>();
 }

--- a/src/main/java/com/grepp/diary/app/model/ai/entity/AiImg.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/entity/AiImg.java
@@ -1,6 +1,7 @@
 package com.grepp.diary.app.model.ai.entity;
 
-import com.grepp.diary.app.model.diary.code.DiaryImgType;
+import com.grepp.diary.app.model.common.code.ImgType;
+import com.grepp.diary.infra.util.file.FileDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -27,7 +28,7 @@ public class AiImg {
     private Integer aiImgId;
     private String savePath;
     @Enumerated(EnumType.STRING)
-    private DiaryImgType type;
+    private ImgType type;
     private String originName;
     private String renamedName;
     private Boolean isUse;
@@ -36,7 +37,14 @@ public class AiImg {
     @JoinColumn(name = "ai_id", nullable = false)
     private Ai ai;
 
+    public AiImg(ImgType type, FileDto fileDto) {
+        this.type = type;
+        this.renamedName = fileDto.renameFileName();
+        this.originName = fileDto.originFileName();
+        this.savePath = fileDto.savePath();
+    }
+
     public String getRenamedPath(){
-        return "/download/" + savePath + renamedName;
+        return "/uploads/" + savePath + renamedName;
     }
 }

--- a/src/main/java/com/grepp/diary/app/model/ai/repository/AiImgRepository.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/repository/AiImgRepository.java
@@ -1,0 +1,8 @@
+package com.grepp.diary.app.model.ai.repository;
+
+import com.grepp.diary.app.model.ai.entity.AiImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AiImgRepository extends JpaRepository<AiImg, Integer>, AiImgRepositoryCustom {
+
+}

--- a/src/main/java/com/grepp/diary/app/model/ai/repository/AiImgRepositoryCustom.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/repository/AiImgRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.grepp.diary.app.model.ai.repository;
+
+public interface AiImgRepositoryCustom {
+    void makeRestImgFalse(Integer aiId);
+}

--- a/src/main/java/com/grepp/diary/app/model/ai/repository/AiImgRepositoryImpl.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/repository/AiImgRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.grepp.diary.app.model.ai.repository;
+
+import com.grepp.diary.app.model.ai.entity.QAi;
+import com.grepp.diary.app.model.ai.entity.QAiImg;
+import com.grepp.diary.app.model.custom.entity.QCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AiImgRepositoryImpl implements AiImgRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+    private final QAiImg aiImg = QAiImg.aiImg;
+
+    @Override
+    public void makeRestImgFalse(Integer aiId) {
+        queryFactory
+            .update(aiImg)
+            .set(aiImg.isUse, false)
+            .where(aiImg.ai.aiId.eq(aiId))
+            .execute();
+    }
+}

--- a/src/main/java/com/grepp/diary/app/model/common/code/ImgType.java
+++ b/src/main/java/com/grepp/diary/app/model/common/code/ImgType.java
@@ -1,0 +1,5 @@
+package com.grepp.diary.app.model.common.code;
+
+public enum ImgType {
+    THUMBNAIL, DESC, LARGE, SMALL, MEDIUM
+}

--- a/src/main/java/com/grepp/diary/app/model/custom/CustomService.java
+++ b/src/main/java/com/grepp/diary/app/model/custom/CustomService.java
@@ -1,6 +1,6 @@
 package com.grepp.diary.app.model.custom;
 
-import com.grepp.diary.app.model.ai.dto.AiAdminDto;
+import com.grepp.diary.app.model.ai.dto.AiWithCountDto;
 import com.grepp.diary.app.model.ai.entity.Ai;
 import com.grepp.diary.app.model.ai.repository.AiRepository;
 import com.grepp.diary.app.model.custom.dto.CustomAIDto;
@@ -20,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -36,7 +35,7 @@ public class CustomService {
         return customRepository.findByMemberUserId(userId);
     }
 
-    public List<AiAdminDto> getAiByLimit(Integer limit) {
+    public List<AiWithCountDto> getAiByLimit(Integer limit) {
         List<Tuple> result = customRepository.getAiByLimit(limit);
 
         return result.stream()
@@ -44,7 +43,7 @@ public class CustomService {
                 Ai ai = tuple.get(0, Ai.class);
                 Long count = tuple.get(1, Long.class);
 
-                AiAdminDto aiDto = mapper.map(ai, AiAdminDto.class);
+                AiWithCountDto aiDto = mapper.map(ai, AiWithCountDto.class);
                 aiDto.setCount(count.intValue());
 
                 return aiDto;

--- a/src/main/java/com/grepp/diary/app/model/diary/DiaryService.java
+++ b/src/main/java/com/grepp/diary/app/model/diary/DiaryService.java
@@ -60,10 +60,7 @@ public class DiaryService {
     private final FileUtil fileUtil;
     /** 시작일과 끝을 기준으로 해당 날짜 사이에 존재하는 일기들을 반환합니다. */
     public List<Diary> getDiariesDateBetween(String userId, LocalDate start, LocalDate end) {
-        LocalDateTime startDateTime = start.atStartOfDay();
-        LocalDateTime endDateTime = end.plusDays(1).atStartOfDay();
-        return diaryRepository.findByMemberUserIdAndCreatedAtBetweenAndIsUseTrue(userId,
-                                                                                 startDateTime, endDateTime);
+        return diaryRepository.findByMemberUserIdAndDateBetweenAndIsUseTrueOrderByDateAsc(userId, start, end);
 
     }
 

--- a/src/main/java/com/grepp/diary/app/model/diary/DiaryService.java
+++ b/src/main/java/com/grepp/diary/app/model/diary/DiaryService.java
@@ -4,7 +4,7 @@ import com.grepp.diary.app.controller.api.diary.payload.DiaryEditRequest;
 import com.grepp.diary.app.controller.web.diary.payload.DiaryRequest;
 import com.grepp.diary.app.model.ai.entity.Ai;
 import com.grepp.diary.app.model.custom.entity.Custom;
-import com.grepp.diary.app.model.diary.code.DiaryImgType;
+import com.grepp.diary.app.model.common.code.ImgType;
 import com.grepp.diary.app.model.diary.code.Emotion;
 import com.grepp.diary.app.model.diary.dto.DiaryDto;
 import com.grepp.diary.app.model.diary.dto.DiaryEmotionAvgDto;
@@ -25,12 +25,8 @@ import com.grepp.diary.infra.response.ResponseCode;
 import com.grepp.diary.infra.util.file.FileDto;
 import com.grepp.diary.infra.util.file.FileUtil;
 import jakarta.persistence.EntityNotFoundException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -40,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -158,8 +153,6 @@ public class DiaryService {
                 throw new CommonException(ResponseCode.DIARY_ALREADY_EXISTS);
             }
 
-            log.info("form : {}", form);
-
             Diary diary = new Diary();
             diary.setEmotion(form.getEmotion());
             diary.setContent(form.getContent());
@@ -197,7 +190,7 @@ public class DiaryService {
             // 사진을 업로드 했을 경우 사진 저장
             if (form.getImages() != null && !form.getImages().isEmpty()) {
                 List<FileDto> imageList = fileUtil.upload(images, "diary", savedDiary.getDiaryId());
-                DiaryImg diaryImg = new DiaryImg(DiaryImgType.THUMBNAIL, imageList.getFirst());
+                DiaryImg diaryImg = new DiaryImg(ImgType.THUMBNAIL, imageList.getFirst());
                 diaryImg.setDiary(diary);
                 diaryImgRepository.save(diaryImg);
 

--- a/src/main/java/com/grepp/diary/app/model/diary/code/DiaryImgType.java
+++ b/src/main/java/com/grepp/diary/app/model/diary/code/DiaryImgType.java
@@ -1,5 +1,0 @@
-package com.grepp.diary.app.model.diary.code;
-
-public enum DiaryImgType {
-    THUMBNAIL, DESC, LARGE, SMALL, MEDIUM
-}

--- a/src/main/java/com/grepp/diary/app/model/diary/entity/DiaryImg.java
+++ b/src/main/java/com/grepp/diary/app/model/diary/entity/DiaryImg.java
@@ -45,6 +45,6 @@ public class DiaryImg {
     }
 
     public String getRenamedPath(){
-        return "/download/" + savePath + renamedName;
+        return "/uploads/" + savePath + renamedName;
     }
 }

--- a/src/main/java/com/grepp/diary/app/model/diary/entity/DiaryImg.java
+++ b/src/main/java/com/grepp/diary/app/model/diary/entity/DiaryImg.java
@@ -1,6 +1,6 @@
 package com.grepp.diary.app.model.diary.entity;
 
-import com.grepp.diary.app.model.diary.code.DiaryImgType;
+import com.grepp.diary.app.model.common.code.ImgType;
 import com.grepp.diary.infra.util.file.FileDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -28,7 +28,7 @@ public class DiaryImg {
     private Integer imgId;
     private String savePath;
     @Enumerated(EnumType.STRING)
-    private DiaryImgType type;
+    private ImgType type;
     private String originName;
     private String renamedName;
     private Boolean isUse = true;
@@ -37,7 +37,7 @@ public class DiaryImg {
     @JoinColumn(name = "diary_id", nullable = false)
     private Diary diary;
 
-    public DiaryImg(DiaryImgType type, FileDto fileDto) {
+    public DiaryImg(ImgType type, FileDto fileDto) {
         this.type = type;
         this.renamedName = fileDto.renameFileName();
         this.originName = fileDto.originFileName();

--- a/src/main/java/com/grepp/diary/app/model/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/grepp/diary/app/model/diary/repository/DiaryRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DiaryRepository extends JpaRepository<Diary, Integer>, DiaryRepositoryCustom {
-    List<Diary> findByMemberUserIdAndCreatedAtBetweenAndIsUseTrue(String userId, LocalDateTime start, LocalDateTime end);
+    List<Diary> findByMemberUserIdAndDateBetweenAndIsUseTrueOrderByDateAsc(String userId, LocalDate start, LocalDate end);
 
     Integer countByCreatedAtBetweenAndIsUseTrue(LocalDateTime startDateTime, LocalDateTime endDateTime);
     Integer countByMemberUserIdAndCreatedAtBetweenAndIsUseTrue(String userId, LocalDateTime start, LocalDateTime end);

--- a/src/main/java/com/grepp/diary/infra/util/file/FileUtil.java
+++ b/src/main/java/com/grepp/diary/infra/util/file/FileUtil.java
@@ -1,6 +1,6 @@
 package com.grepp.diary.infra.util.file;
 
-import com.grepp.diary.app.model.diary.code.DiaryImgType;
+import com.grepp.diary.app.model.common.code.ImgType;
 import com.grepp.diary.app.model.diary.entity.Diary;
 import com.grepp.diary.app.model.diary.entity.DiaryImg;
 import java.io.File;
@@ -65,7 +65,7 @@ public class FileUtil {
         img.setOriginName(originalFilename);
         img.setRenamedName(renamedName);
         img.setSavePath(webPath);
-        img.setType(DiaryImgType.THUMBNAIL); // 기본 타입
+        img.setType(ImgType.THUMBNAIL); // 기본 타입
         img.setIsUse(true);
         return img;
     }

--- a/src/main/resources/static/css/card-list.css
+++ b/src/main/resources/static/css/card-list.css
@@ -84,13 +84,12 @@
   color: #FEFBF6;
 }
 
-.diary-card.with-image::before {
-  content: "";
+.diary-card .image-overlay {
   position: absolute;
   inset: 0;
   background-size: cover;
   background-position: center;
-  opacity: 0.5;
+  opacity: 0.5; /* ← 여기서 조정 */
   z-index: 0;
 }
 

--- a/src/main/resources/static/js/admin-ai-write.js
+++ b/src/main/resources/static/js/admin-ai-write.js
@@ -24,6 +24,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       mbtiInput.value = ai.mbti || '';
       infoInput.value = ai.info || '';
       promptInput.value = ai.prompt || '';
+
+      if (ai.images && ai.images.length > 0) {
+        const thumbImage = ai.images.find(img => img.type === 'THUMBNAIL') || ai.images[0];
+
+        thumbnail.src = thumbImage.renamedName;
+        thumbnail.style.display = 'block';
+      }
     } catch (err) {
       console.error('AI 데이터 로드 오류:', err);
       alert('AI 캐릭터 정보를 불러오지 못했습니다.');
@@ -51,19 +58,21 @@ document.addEventListener('DOMContentLoaded', async () => {
     const mbti = mbtiInput.value.trim();
     const info = infoInput.value.trim();
     const prompt = promptInput.value.trim();
+    const imageFile = imageInput.files[0];
 
     if (!name) return alert('이름을 입력하세요');
     if (!mbti) return alert('MBTI를 입력하세요');
     if (!info) return alert('소개글을 입력하세요');
     if (!prompt) return alert('프롬프트를 입력하세요');
+    if (!thumbnail.src) return alert('사진을 업로드하세요');
 
-    const aiData = {
-      id: editingAiId ? parseInt(editingAiId) : null,
-      name,
-      mbti,
-      info,
-      prompt
-    };
+    const formData = new FormData();
+    if(editingAiId) formData.append('id', editingAiId);
+    formData.append('name', name);
+    formData.append('mbti', mbti);
+    formData.append('info', info);
+    formData.append('prompt', prompt);
+    if(imageFile) formData.append('images', imageFile);
 
     try {
       const url = editingAiId ? '/api/admin/ai/modify' : '/api/admin/ai';
@@ -71,8 +80,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       const res = await fetch(url, {
         method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(aiData)
+        body: formData
       });
 
       if (!res.ok) throw new Error(editingAiId ? '수정 실패' : '등록 실패');

--- a/src/main/resources/static/js/calendar.js
+++ b/src/main/resources/static/js/calendar.js
@@ -78,7 +78,7 @@ function renderCalendar(date, emotionMap = {}) {
       const dateParam = `${year}-${String(month + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
 
       try {
-        const res = await fetch(`/api/diary/check?userId=user01&date=${dateParam}`);
+        const res = await fetch(`/api/diary/check?date=${dateParam}`);
         const exists = await res.json();
 
         if (exists) {
@@ -98,8 +98,7 @@ function renderCalendar(date, emotionMap = {}) {
 }
 
 async function fetchEmotionData(year, month) {
-  //TODO : Auth 구현이 완료되면 사용자 아이디 동적으로 받아올 수 있도록 할 것
-  const response = await fetch(`/api/diary/calendar?userId=user01&year=${year}&month=${month}`);
+  const response = await fetch(`/api/diary/calendar?year=${year}&month=${month}`);
   const data = await response.json();
 
   const emotionMap = {};

--- a/src/main/resources/static/js/card-list.js
+++ b/src/main/resources/static/js/card-list.js
@@ -13,7 +13,12 @@ async function loadRecentDiaries() {
     // 배경/글자 설정
     if (diary.imagePath) {
       card.classList.add("with-image");
-      card.style.backgroundImage = `url('${diary.imagePath}')`;
+
+      // 오버레이용 div
+      const overlay = document.createElement("div");
+      overlay.className = "image-overlay";
+      overlay.style.backgroundImage = `url('${diary.imagePath}')`;
+      card.appendChild(overlay);
     } else {
       card.classList.add("no-image");
     }

--- a/src/main/resources/static/js/card-list.js
+++ b/src/main/resources/static/js/card-list.js
@@ -1,5 +1,5 @@
-async function loadRecentDiaries(userId) {
-  const response = await fetch(`/api/diary/cards?userId=${userId}`);
+async function loadRecentDiaries() {
+  const response = await fetch(`/api/diary/cards`);
   const data = await response.json();
   const diaries = data.diaryCards;
 
@@ -42,7 +42,5 @@ async function loadRecentDiaries(userId) {
   });
 }
 document.addEventListener("DOMContentLoaded", () => {
-  //TODO : Auth 구현이 완료되면 사용자 아이디 동적으로 받아올 수 있도록 할 것
-  const userId = "user01"; // 실제 사용자 ID로 교체
-  loadRecentDiaries(userId);
+  loadRecentDiaries();
 });

--- a/src/main/resources/static/js/card-timeline.js
+++ b/src/main/resources/static/js/card-timeline.js
@@ -3,8 +3,7 @@ let isLoading = false;
 const PAGE_SIZE = 30;
 
 document.addEventListener("DOMContentLoaded", () => {
-  const userId = "user01"; // TODO: 실제 로그인된 사용자 ID로 대체
-  loadNextPage(userId);
+  loadNextPage();
 
   // 무한 스크롤 감지
   window.addEventListener("scroll", () => {
@@ -12,17 +11,17 @@ document.addEventListener("DOMContentLoaded", () => {
         window.innerHeight + window.scrollY >= document.body.offsetHeight - 100 &&
         !isLoading
     ) {
-      loadNextPage(userId);
+      loadNextPage();
     }
   });
 });
 
-async function loadNextPage(userId) {
+async function loadNextPage() {
   isLoading = true;
 
   try {
     const response = await fetch(
-        `/api/diary/cards?userId=${userId}&page=${currentPage}`
+        `/api/diary/cards?page=${currentPage}`
     );
     const data = await response.json();
     const diaries = data.diaryCards || [];

--- a/src/main/resources/templates/app/member-dashboard.html
+++ b/src/main/resources/templates/app/member-dashboard.html
@@ -26,7 +26,6 @@
           <button class="toggle-btn" id="yearly">연간</button>
         </div>
         <!-- AI 한마디 -->
-        AI 한마디
       </div>
       <div class="dashboard-content">
         <!-- 1행: 감정 흐름 -->


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 설명
- 대시보드에서 AI의 코멘트를 구현하지 않기로 결정되어 해당 구역을 삭제하였습니다.
- 기존 useId를 파라메터로 받던 API들을 인증된 유저의 정보를 가져오는 방식으로 수정하였습니다

## 👩‍💻 구현 내용
### 💄 Remove AI comment section
- 대시보드에서 AI의 코멘트를 구현하지 않기로 결정되어 해당 구역을 삭제하였습니다.

### ♻️ Use diary date instead of creation date when returning diary data
- 다이어리 데이터 반환시 생성시간을 반환하던 부분을 일기의 날짜를 반환하도록 수정하였습니다.

### ♻️ Sort diary data by diary date in ascending order when fetching fro…
- 대시보드 차트 생성시 데이터의 순서 기준이 없어 이상하게 그려지는 현상을 발견했습니다.
- 따라서 다이어리 DB 조회 후, 반환할때 일기의 날짜를 기준으로 오름차순 정렬이 되도록 수정하였습니다.

### ♻️ Refactor APIs to use Authentication instead of userId parameter
- 기존 useId를 파라메터로 받던 API들을 인증된 유저의 정보를 가져오는 방식으로 수정하였습니다

### 🐛 Fix image transparency issue
- 최근 항목에서 이미지 투명화가 제대로 적용되지 않던 문제를 해결했습니다.
