### PR TITLE
Display AI profile image in AI setting page UI

### DIFF
--- a/src/main/java/com/grepp/diary/app/controller/api/ai/payload/AiListResponse.java
+++ b/src/main/java/com/grepp/diary/app/controller/api/ai/payload/AiListResponse.java
@@ -2,8 +2,6 @@ package com.grepp.diary.app.controller.api.ai.payload;
 
 import com.grepp.diary.app.model.ai.dto.AiInfoDto;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 
 public record AiListResponse(
     List<AiInfo> aiInfoList
@@ -13,15 +11,19 @@ public record AiListResponse(
         String name,
         String mbti,
         String info,
-        String savePath
+        String renamedPath
     ) {
         public static AiInfo fromDto(AiInfoDto aiInfoDto) {
+            String imagePath = null;
+
+            imagePath = aiInfoDto.getRenamedPath();
+
             return new AiInfo(
                 aiInfoDto.getAiId(),
                 aiInfoDto.getName(),
                 aiInfoDto.getMbti(),
                 aiInfoDto.getInfo(),
-                aiInfoDto.getImgUrl()
+                imagePath
             );
         }
     }

--- a/src/main/java/com/grepp/diary/app/model/ai/dto/AiInfoDto.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/dto/AiInfoDto.java
@@ -1,9 +1,11 @@
 package com.grepp.diary.app.model.ai.dto;
 
+import com.grepp.diary.app.model.ai.entity.Ai;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @Data
@@ -16,5 +18,10 @@ public class AiInfoDto {
     private String name;
     private String mbti;
     private String info;
-    private String imgUrl;
+    private String savePath;
+    private String renamedName;
+
+    public String getRenamedPath(){
+        return savePath != null && renamedName != null ? "/uploads/" + savePath + renamedName : null;
+    }
 }

--- a/src/main/java/com/grepp/diary/app/model/ai/repository/AIRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/diary/app/model/ai/repository/AIRepositoryCustomImpl.java
@@ -26,7 +26,8 @@ public class AIRepositoryCustomImpl implements AIRepositoryCustom {
                 ai.name,
                 ai.mbti,
                 ai.info,
-                aiImg.savePath
+                aiImg.savePath,
+                aiImg.renamedName
             ))
             .from(ai)
             .leftJoin(aiImg)

--- a/src/main/resources/static/css/settings.css
+++ b/src/main/resources/static/css/settings.css
@@ -150,6 +150,21 @@
   border-radius: 50%;
   background-color: #ADAB9F;
   margin: 0 auto 16px;
+  overflow: hidden;
+  border: 3px solid #ADAB9F;
+}
+
+/* 선택된 AI 카드의 이미지에 초록 테두리 */
+.ai-card.selected .ai-image {
+  border: 3px solid #467750;
+}
+
+.ai-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
 }
 
 .ai-name {

--- a/src/main/resources/static/js/settings.js
+++ b/src/main/resources/static/js/settings.js
@@ -49,7 +49,9 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       card.innerHTML = `
-          <div class="ai-image"></div>
+          <div class="ai-image">
+            <img src="${ai.renamedPath}" alt="${ai.name}" />
+          </div>
           <div class="ai-name">${ai.name}</div>
           <div class="ai-mbti">${ai.mbti}</div>
           <div class="ai-info">${ai.info}</div>

--- a/src/main/resources/templates/diary/write-diary.html
+++ b/src/main/resources/templates/diary/write-diary.html
@@ -137,7 +137,7 @@
         <div class="form-box">
           <div class="form-group full-width">
             <label>당신의 하루를 자세히 들려주세요.</label>
-            <textarea th:field="*{content}" placeholder="솔직하고 편하게 써주세요!" rows="6" class="diary-content-input" required></textarea>
+            <textarea th:field="*{content}" placeholder="편하게 이야기해주세요 :)" rows="6" class="diary-content-input" required></textarea>
             <div style="text-align: right; font-size: 0.9rem; color: #555;">
               <span id="char-count">0 / 1000자</span>
             </div>


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

![스크린샷 2025-05-20 오후 3 16 34](https://github.com/user-attachments/assets/860ccc22-edd2-4fa9-9ba9-84c369c4abbc)

## 📌 설명
- 이제 AI 설정 페이지에서 AI의 프로필 사진이 표시됩니다.

## 👩‍💻 구현 내용
###💄 Improve diary write page
- 일기 작성 구역의 기본 텍스트를 변경하였습니다.

### ♻️ Fix dto and related methods
- AI 이미지를 불러오기 위한 dto에서 이미지부분을 재구성하고 관련 매서드들을 수정하였습니다

### 💄 Display AI profile image in AI setting page UI
- 이제 AI 설정 페이지에서 AI의 프로필 사진이 표시됩니다.
