### PR TITLE
🐛 Fix Chat button rendering option

### DIFF
--- a/src/main/resources/templates/diary/record.html
+++ b/src/main/resources/templates/diary/record.html
@@ -89,7 +89,7 @@
         </div>
         <!-- diary 생성일자가 7일 이내일 경우에만 채팅버튼 생성 -->
         <div class="chat-btn-wrapper"
-             th:if="${diary.reply != null} and ${T(java.time.LocalDate).now().minusDays(7).isBefore(diary.getCreatedAt().toLocalDate())}">
+             th:if="${diary.reply != null} and ${T(java.time.LocalDate).now().minusDays(7).isBefore(diary.getCreatedAt().toLocalDate())} and ${diary.reply.getCreatedAt() == diary.reply.getModifiedAt()}">
           <!--        <div class="chat-btn-wrapper" th:if="${diary.reply != null}">-->
           <div class="chat-btn" onclick="chat()">
             <i class="fa-regular fa-message" style="margin-right: 7px"></i>


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 이미 대화를 한 후 메모를 했으면 더 이상 대화 버튼이 생기지 않도록 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
🐛 Fix Chat button rendering option
- ${diary.reply.getCreatedAt() == diary.reply.getModifiedAt()} 
- 메모 시 기존의 답변을 업데이트하므로 ModifiedAt 변경 -> 해당 커럼을 기준으로 조건 추가
